### PR TITLE
added new enum, changed methods to stay consistent

### DIFF
--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -7,7 +7,7 @@ export enum Status {
   PAUSED,
   ENDED,
   ERRORED,
-  STUCKED
+  STUCK
 }
 
 export default class Player extends EventEmitter {
@@ -23,7 +23,7 @@ export default class Player extends EventEmitter {
     this.on('event', (d) => {
       if (d.type === 'TrackEndEvent') this.status = Status.ENDED;
       else if (d.type === "TrackExceptionEvent") this.status = Status.ERRORED
-      else this.status = Status.STUCKED;
+      else this.status = Status.STUCK;
     })
   }
 

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -7,6 +7,7 @@ export enum Status {
   PAUSED,
   ENDED,
   ERRORED,
+  STUCKED
 }
 
 export default class Player extends EventEmitter {
@@ -21,7 +22,8 @@ export default class Player extends EventEmitter {
 
     this.on('event', (d) => {
       if (d.type === 'TrackEndEvent') this.status = Status.ENDED;
-      else this.status = Status.ERRORED;
+      else if (d.type === "TrackExceptionEvent") this.status = Status.ERRORED
+      else this.status = Status.STUCKED;
     })
   }
 
@@ -78,15 +80,15 @@ export default class Player extends EventEmitter {
     return this.send('seek', { position });
   }
 
-  public pause(paused: boolean = true) {
+  public async pause(paused: boolean = true) {
+    await this.send('pause', { pause: paused });
+
     if (paused) this.status = Status.PAUSED;
     else this.status = Status.PLAYING;
-
-    return this.send('pause', { pause: paused });
   }
 
   public async stop() {
-    await this.send('stop');
+    return this.send('stop');
   }
 
   public voiceUpdate(sessionId: string, event: VoiceServerUpdate) {

--- a/src/core/Player.ts
+++ b/src/core/Player.ts
@@ -87,7 +87,7 @@ export default class Player extends EventEmitter {
     else this.status = Status.PLAYING;
   }
 
-  public async stop() {
+  public stop() {
     return this.send('stop');
   }
 


### PR DESCRIPTION
i added a new enum for stuck since TrackStuckEvent and TrackExeptionEvent force you to do different things while TrackExeptionEvent will always aswell emit an TrackEndEvent and end the track itself TrackStuckEvent doesn't do that and you need to play another track yourself. 